### PR TITLE
style: remove header image and fix EOF newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 [![License]][license_url]
 <p>A powerful tool that leverages multimodal large language models to transcribe PDF files into Markdown format.</p>
 
-![markpdfdown](https://raw.githubusercontent.com/markpdfdown/markpdfdown/refs/heads/master/tests/fixtures/images/markpdfdown.png)
-
 </div>
 
 ## Desktop App

--- a/README_ar.md
+++ b/README_ar.md
@@ -9,8 +9,6 @@
 [![License]][license_url]
 <p>أداة قوية تستخدم نماذج اللغة الكبيرة متعددة الوسائط لتحويل ملفات PDF إلى تنسيق Markdown.</p>
 
-![markpdfdown](https://raw.githubusercontent.com/markpdfdown/markpdfdown/refs/heads/master/tests/fixtures/images/markpdfdown.png)
-
 </div>
 
 <div dir="rtl">

--- a/README_fa.md
+++ b/README_fa.md
@@ -9,8 +9,6 @@
 [![License]][license_url]
 <p>ابزاری قدرتمند که از مدل‌های زبانی بزرگ چندوجهی برای تبدیل فایل‌های PDF به فرمت Markdown استفاده می‌کند.</p>
 
-![markpdfdown](https://raw.githubusercontent.com/markpdfdown/markpdfdown/refs/heads/master/tests/fixtures/images/markpdfdown.png)
-
 </div>
 
 <div dir="rtl">

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,8 +9,6 @@
 [![License]][license_url]
 <p>マルチモーダル大規模言語モデルを活用して、PDFファイルをMarkdown形式に変換する強力なツールです。</p>
 
-![markpdfdown](https://raw.githubusercontent.com/markpdfdown/markpdfdown/refs/heads/master/tests/fixtures/images/markpdfdown.png)
-
 </div>
 
 ## デスクトップアプリ

--- a/README_ru.md
+++ b/README_ru.md
@@ -9,8 +9,6 @@
 [![License]][license_url]
 <p>Мощный инструмент, использующий мультимодальные большие языковые модели для преобразования PDF-файлов в формат Markdown.</p>
 
-![markpdfdown](https://raw.githubusercontent.com/markpdfdown/markpdfdown/refs/heads/master/tests/fixtures/images/markpdfdown.png)
-
 </div>
 
 ## Настольное приложение


### PR DESCRIPTION
## Summary

- Remove markpdfdown header image from all README files
- Add trailing newline at end of files for proper formatting

## Files Changed

- README.md
- README_ar.md
- README_fa.md
- README_ja.md
- README_ru.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)